### PR TITLE
Improve documentation and typing hygiene

### DIFF
--- a/src/pure_function_decorators/__init__.py
+++ b/src/pure_function_decorators/__init__.py
@@ -1,3 +1,5 @@
+"""Public package surface for the pure-function-decorators project."""
+
 from .detect_immutable import detect_immutable
 from .enforce_deterministic import enforce_deterministic
 from .enforce_immutable import enforce_immutable
@@ -9,7 +11,7 @@ __all__ = [
     "detect_immutable",
     "enforce_deterministic",
     "enforce_immutable",
-    "forbid_globals",
     "forbid_global_names",
+    "forbid_globals",
     "forbid_side_effects",
 ]

--- a/src/pure_function_decorators/detect_immutable.py
+++ b/src/pure_function_decorators/detect_immutable.py
@@ -1,97 +1,146 @@
+"""Utilities for detecting in-place mutations performed by callables."""
+# ruff: noqa: ANN401
+
+from __future__ import annotations
+
 import copy
 from functools import wraps
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+else:  # pragma: no cover - provide runtime aliases for introspection tools
+    import collections.abc as _abc
+
+    Callable = _abc.Callable
+    Iterable = _abc.Iterable
+    Mapping = _abc.Mapping
+    Sequence = _abc.Sequence
+
+_Path = tuple[str, ...]
+_Diff = tuple[_Path, str]
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
-def _first_diff(
-    a: Any, b: Any, path: Tuple[str, ...] = ()
-) -> Optional[Tuple[Tuple[str, ...], str]]:
-    # Type changed
-    if type(a) is not type(b):
-        return path, f"type {type(a).__name__} -> {type(b).__name__}"
+def _describe_collection(items: Iterable[Any]) -> str:
+    return "[" + ", ".join(sorted(repr(item) for item in items)) + "]"
 
-    # Dicts
-    if isinstance(a, dict):
-        ak, bk = set(a.keys()), set(b.keys())
-        if ak != bk:
-            missing = ak - bk
-            added = bk - ak
-            if missing:
-                return path + ("<dict-keys>",), f"missing keys {sorted(missing)!r}"
-            if added:
-                return path + ("<dict-keys>",), f"added keys {sorted(added)!r}"
-        for k in a:
-            d = _first_diff(a[k], b[k], path + (f"[{k!r}]",))
-            if d:
-                return d
-        return None
 
-    # Lists / tuples
-    if isinstance(a, (list, tuple)):
-        if len(a) != len(b):
-            return path + ("<len>",), f"{len(a)} -> {len(b)}"
-        for i, (ai, bi) in enumerate(zip(a, b)):
-            d = _first_diff(ai, bi, path + (f"[{i}]",))
-            if d:
-                return d
-        return None
-
-    # Sets / frozensets
-    if isinstance(a, (set, frozenset)):
-        if a != b:
-            removed = a - b
-            added = b - a
-            return path, f"set changed; -{sorted(removed)!r} +{sorted(added)!r}"
-        return None
-
-    # Dataclass/objects with __dict__ (shallow heuristic)
-    if hasattr(a, "__dict__") and hasattr(b, "__dict__"):
-        return _first_diff(a.__dict__, b.__dict__, path + (".__dict__",))
-
-    # Fallback equality
-    if a != b:
-        # Truncate long reprs for readability
-        ra = repr(a)
-        rb = repr(b)
-        if len(ra) > 200:
-            ra = ra[:197] + "..."
-        if len(rb) > 200:
-            rb = rb[:197] + "..."
-        return path, f"value {ra} -> {rb}"
+def _compare_sequence(
+    seq_a: Sequence[Any], seq_b: Sequence[Any], path: _Path
+) -> _Diff | None:
+    if len(seq_a) != len(seq_b):
+        return (*path, "<len>"), f"{len(seq_a)} -> {len(seq_b)}"
+    for index, (left, right) in enumerate(zip(seq_a, seq_b, strict=True)):
+        diff = _first_diff(left, right, (*path, f"[{index}]"))
+        if diff:
+            return diff
     return None
 
 
-def detect_immutable(fn):
-    """
-    Detects in-place modifications of any passed-in argument.
-    Takes deep snapshots before the call and diffs after the call.
-    Not thread-safe. Does not catch mutations that occur after return (e.g., background threads).
-    """
+def _first_diff(a: Any, b: Any, path: _Path = ()) -> _Diff | None:
+    """Return the first difference between ``a`` and ``b`` (if any)."""
+    if type(a) is not type(b):
+        return path, f"type {type(a).__name__} -> {type(b).__name__}"
+
+    if isinstance(a, dict) and isinstance(b, dict):
+        a_dict = cast("dict[object, object]", a)
+        b_dict = cast("dict[object, object]", b)
+        a_keys: set[object] = set(a_dict.keys())
+        b_keys: set[object] = set(b_dict.keys())
+        if a_keys != b_keys:
+            missing = a_keys - b_keys
+            added = b_keys - a_keys
+            if missing:
+                return (
+                    *path,
+                    "<dict-keys>",
+                ), f"missing keys {_describe_collection(missing)}"
+            if added:
+                return (
+                    *path,
+                    "<dict-keys>",
+                ), f"added keys {_describe_collection(added)}"
+        for key in a_dict:
+            diff = _first_diff(a_dict[key], b_dict[key], (*path, f"[{key!r}]"))
+            if diff:
+                return diff
+        return None
+
+    if isinstance(a, list) and isinstance(b, list):
+        return _compare_sequence(
+            cast("Sequence[Any]", a), cast("Sequence[Any]", b), path
+        )
+
+    if isinstance(a, tuple) and isinstance(b, tuple):
+        return _compare_sequence(
+            cast("Sequence[Any]", a), cast("Sequence[Any]", b), path
+        )
+
+    if isinstance(a, set) and isinstance(b, set):
+        a_set = a
+        b_set = b
+        if a_set != b_set:
+            removed_desc = _describe_collection(a_set - b_set)
+            added_desc = _describe_collection(b_set - a_set)
+            return path, f"set changed; -{removed_desc} +{added_desc}"
+        return None
+
+    if isinstance(a, frozenset) and isinstance(b, frozenset):
+        a_items = set(a)
+        b_items = set(b)
+        if a_items != b_items:
+            removed_desc = _describe_collection(a_items - b_items)
+            added_desc = _describe_collection(b_items - a_items)
+            return path, f"set changed; -{removed_desc} +{added_desc}"
+        return None
+
+    a_obj: object = a
+    b_obj: object = b
+    if hasattr(a_obj, "__dict__") and hasattr(b_obj, "__dict__"):
+        a_mapping = cast("Mapping[str, Any]", a_obj.__dict__)
+        b_mapping = cast("Mapping[str, Any]", b_obj.__dict__)
+        return _first_diff(a_mapping, b_mapping, (*path, ".__dict__"))
+
+    if a_obj != b_obj:
+        left_repr = repr(a_obj)
+        right_repr = repr(b_obj)
+        if len(left_repr) > 200:
+            left_repr = f"{left_repr[:197]}..."
+        if len(right_repr) > 200:
+            right_repr = f"{right_repr[:197]}..."
+        return path, f"value {left_repr} -> {right_repr}"
+    return None
+
+
+def detect_immutable(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Raise ``RuntimeError`` if ``fn`` mutates its arguments in-place."""
 
     @wraps(fn)
-    def wrapper(*args, **kwargs):
-        # Deep snapshots (preserve aliasing graph via memo)
-        memo = {}
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        memo: dict[int, object] = {}
         args_snapshot = copy.deepcopy(args, memo)
         kwargs_snapshot = copy.deepcopy(kwargs, memo)
 
         result = fn(*args, **kwargs)
 
-        # Compare positional args
-        for i, (orig, snap) in enumerate(zip(args, args_snapshot)):
-            diff = _first_diff(orig, snap, path=(f"arg[{i}]",))
+        for index, (original, snapshot) in enumerate(
+            zip(args, args_snapshot, strict=True)
+        ):
+            diff = _first_diff(original, snapshot, path=(f"arg[{index}]",))
             if diff:
-                path, msg = diff
-                raise RuntimeError(f"Argument mutated at {'/'.join(path)}: {msg}")
+                diff_path, message = diff
+                joined = "/".join(diff_path)
+                raise RuntimeError(f"Argument mutated at {joined}: {message}")
 
-        # Compare kwargs
-        for k in kwargs:
-            orig = kwargs[k]
-            snap = kwargs_snapshot[k]
-            diff = _first_diff(orig, snap, path=(f"kwarg[{k!r}]",))
+        for key, original in kwargs.items():
+            snapshot = kwargs_snapshot[key]
+            diff = _first_diff(original, snapshot, path=(f"kwarg[{key!r}]",))
             if diff:
-                path, msg = diff
-                raise RuntimeError(f"Argument mutated at {'/'.join(path)}: {msg}")
+                diff_path, message = diff
+                joined = "/".join(diff_path)
+                raise RuntimeError(f"Argument mutated at {joined}: {message}")
 
         return result
 

--- a/src/pure_function_decorators/enforce_deterministic.py
+++ b/src/pure_function_decorators/enforce_deterministic.py
@@ -1,12 +1,28 @@
+"""Decorator that ensures a callable produces deterministic outputs."""
+
+from __future__ import annotations
+
 import pickle
 from functools import wraps
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+else:  # pragma: no cover
+    import collections.abc as _abc
+
+    Callable = _abc.Callable
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
-def enforce_deterministic(fn):
-    cache = {}
+def enforce_deterministic(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Raise ``ValueError`` if ``fn`` returns different results for the same inputs."""
+    cache: dict[bytes, _T] = {}
 
     @wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         key = pickle.dumps((args, kwargs))
         result = fn(*args, **kwargs)
         if key in cache and cache[key] != result:

--- a/src/pure_function_decorators/enforce_immutable.py
+++ b/src/pure_function_decorators/enforce_immutable.py
@@ -1,13 +1,29 @@
+"""Decorator that deep-copies inputs before invoking the wrapped callable."""
+
+from __future__ import annotations
+
 import copy
 from functools import wraps
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+else:  # pragma: no cover
+    import collections.abc as _abc
+
+    Callable = _abc.Callable
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
-def enforce_immutable(fn):
+def enforce_immutable(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Invoke ``fn`` with deep-copied arguments to prevent caller mutations."""
+
     @wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         frozen_args = copy.deepcopy(args)
         frozen_kwargs = copy.deepcopy(kwargs)
-        result = fn(*frozen_args, **frozen_kwargs)
-        return result
+        return fn(*frozen_args, **frozen_kwargs)
 
     return wrapper

--- a/src/pure_function_decorators/forbid_side_effects.py
+++ b/src/pure_function_decorators/forbid_side_effects.py
@@ -1,7 +1,12 @@
+"""Heuristic decorator that blocks common side effects during a call."""
+
+from __future__ import annotations
+
 import atexit
 import builtins
 import concurrent.futures as futures
 import datetime
+import importlib
 import logging
 import multiprocessing
 import os
@@ -14,42 +19,56 @@ import threading
 import time
 import uuid
 import warnings
+from contextlib import suppress
 from functools import wraps
+from typing import TYPE_CHECKING, NoReturn, ParamSpec, TypeVar, override
 
-# Heuristic purity guard: blocks common side effects during the wrapped call.
-# Restores originals after execution. Not thread-safe. Best for tests.
+if TYPE_CHECKING:
+    from collections.abc import Callable
+else:  # pragma: no cover
+    import collections.abc as _abc
+
+    Callable = _abc.Callable
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
-def _trap(name):
-    def _raiser(*a, **k):
+def _trap(name: str) -> Callable[..., NoReturn]:
+    """Return a callable that raises ``RuntimeError`` when invoked."""
+
+    def _raiser(*_args: object, **_kwargs: object) -> NoReturn:
         raise RuntimeError(f"Side effect blocked: {name}")
 
     return _raiser
 
 
 class _TrapStdIO:
-    def write(self, *_a, **_k):
+    """File-like object that rejects writes to stdout/stderr."""
+
+    def write(self, *_args: object, **_kwargs: object) -> NoReturn:
         raise RuntimeError("Side effect blocked: stdio write")
 
-    def flush(self):  # some code calls flush unconditionally
-        pass
+    def flush(self) -> None:
+        """Provide a harmless flush implementation for callers that expect one."""
+        return None
 
 
-def forbid_side_effects(fn):
+def forbid_side_effects(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Reject attempts to perform common side effects while ``fn`` runs."""
+
     @wraps(fn)
-    def wrapper(*args, **kwargs):
-        patches = []
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        patches: list[tuple[object, str, object]] = []
 
-        def patch(obj, attr, repl):
+        def patch(obj: object, attr: str, repl: object) -> None:
             original = getattr(obj, attr)
             setattr(obj, attr, repl)
             patches.append((obj, attr, original))
 
-        # builtins I/O and process
         patch(builtins, "print", _trap("print"))
         patch(builtins, "open", _trap("open"))
 
-        # randomness
         patch(random, "random", _trap("random.random"))
         patch(random, "randint", _trap("random.randint"))
         patch(random, "randrange", _trap("random.randrange"))
@@ -61,79 +80,74 @@ def forbid_side_effects(fn):
         patch(os, "urandom", _trap("os.urandom"))
         patch(uuid, "uuid4", _trap("uuid.uuid4"))
 
-        # time
         patch(time, "time", _trap("time.time"))
         patch(time, "sleep", _trap("time.sleep"))
         patch(time, "monotonic", _trap("time.monotonic"))
         patch(time, "perf_counter", _trap("time.perf_counter"))
 
-        # datetime (replace class with trap subclass)
-        _orig_datetime_cls = datetime.datetime
-
-        class _TrapDateTime(datetime.datetime):  # type: ignore[misc]
+        class _TrapDateTime(datetime.datetime):
+            @override
             @classmethod
-            def now(cls, *a, **k):
+            def now(cls, *_args: object, **_kwargs: object) -> NoReturn:
                 raise RuntimeError("Side effect blocked: datetime.now")
 
+            @override
             @classmethod
-            def utcnow(cls, *a, **k):
+            def utcnow(cls, *_args: object, **_kwargs: object) -> NoReturn:
                 raise RuntimeError("Side effect blocked: datetime.utcnow")
 
+            @override
             @classmethod
-            def today(cls, *a, **k):
+            def today(cls, *_args: object, **_kwargs: object) -> NoReturn:
                 raise RuntimeError("Side effect blocked: datetime.today")
 
-        datetime.datetime = _TrapDateTime  # type: ignore[assignment]
+        patch(datetime, "datetime", _TrapDateTime)
 
-        # environment
         patch(os, "getenv", _trap("os.getenv"))
-        # wrap os.environ mapping to block get/set/del
-        _orig_environ = os.environ
 
-        class _TrapEnviron(dict):
-            def __getitem__(self, k):
+        class _TrapEnviron(dict[str, object]):
+            @override
+            def __getitem__(self, _key: str) -> NoReturn:
                 raise RuntimeError("Side effect blocked: os.environ[] read")
 
-            def __setitem__(self, k, v):
+            @override
+            def __setitem__(self, _key: str, _value: object) -> NoReturn:
                 raise RuntimeError("Side effect blocked: os.environ[] write")
 
-            def get(self, k, d=None):
+            @override
+            def get(self, _key: str, _default: object | None = None) -> NoReturn:
                 raise RuntimeError("Side effect blocked: os.environ.get")
 
-            def __delitem__(self, k):
+            @override
+            def __delitem__(self, _key: str) -> NoReturn:
                 raise RuntimeError("Side effect blocked: os.environ del")
 
-        os.environ = _TrapEnviron()  # type: ignore[assignment]
+        patch(os, "environ", _TrapEnviron())
 
-        # OS commands and process control
         patch(os, "system", _trap("os.system"))
         patch(os, "popen", _trap("os.popen"))
         patch(os, "_exit", _trap("os._exit"))
         patch(sys, "exit", _trap("sys.exit"))
 
-        # subprocess
         patch(subprocess, "run", _trap("subprocess.run"))
         patch(subprocess, "Popen", _trap("subprocess.Popen"))
         patch(subprocess, "call", _trap("subprocess.call"))
         patch(subprocess, "check_call", _trap("subprocess.check_call"))
         patch(subprocess, "check_output", _trap("subprocess.check_output"))
 
-        # networking
         patch(socket, "socket", _trap("socket.socket"))
-        # optional: block common high-level clients if present
-        try:
+        with suppress(Exception):
             import http.client as http_client
 
             patch(http_client, "HTTPConnection", _trap("http.client.HTTPConnection"))
             patch(http_client, "HTTPSConnection", _trap("http.client.HTTPSConnection"))
-        except Exception:
-            pass
 
-        # threading / multiprocessing / executors
         patch(threading.Thread, "start", _trap("threading.Thread.start"))
         patch(multiprocessing.Process, "start", _trap("multiprocessing.Process.start"))
         patch(
-            futures.ThreadPoolExecutor, "__init__", _trap("ThreadPoolExecutor.__init__")
+            futures.ThreadPoolExecutor,
+            "__init__",
+            _trap("ThreadPoolExecutor.__init__"),
         )
         patch(
             futures.ProcessPoolExecutor,
@@ -141,49 +155,32 @@ def forbid_side_effects(fn):
             _trap("ProcessPoolExecutor.__init__"),
         )
 
-        # logging and warnings
         patch(logging.Logger, "_log", _trap("logging"))
         patch(warnings, "warn", _trap("warnings.warn"))
 
-        # atexit
         patch(atexit, "register", _trap("atexit.register"))
 
-        # stdio writes (avoid swapping objects; trap writes instead)
-        _saved_stdout, _saved_stderr = sys.stdout, sys.stderr
-        sys.stdout = _TrapStdIO()  # type: ignore[assignment]
-        sys.stderr = _TrapStdIO()  # type: ignore[assignment]
+        patch(sys, "stdout", _TrapStdIO())
+        patch(sys, "stderr", _TrapStdIO())
 
-        # optional: sqlite3 and common DB connectors if available
-        try:
-            import sqlite3
-
+        with suppress(Exception):
+            sqlite3 = importlib.import_module("sqlite3")
             patch(sqlite3, "connect", _trap("sqlite3.connect"))
-        except Exception:
-            pass
-        try:
-            import psycopg2  # type: ignore
-
+        with suppress(Exception):
+            psycopg2 = importlib.import_module("psycopg2")
             patch(psycopg2, "connect", _trap("psycopg2.connect"))
-        except Exception:
-            pass
-        try:
-            import mysql.connector as mysql_connector  # type: ignore
-
-            patch(mysql_connector, "connect", _trap("mysql.connector.connect"))
-        except Exception:
-            pass
+        with suppress(Exception):
+            mysql_connector = importlib.import_module("mysql.connector")
+            patch(
+                mysql_connector,
+                "connect",
+                _trap("mysql.connector.connect"),
+            )
 
         try:
             return fn(*args, **kwargs)
         finally:
-            # restore patched attributes
             for obj, attr, original in reversed(patches):
                 setattr(obj, attr, original)
-            # restore datetime class
-            datetime.datetime = _orig_datetime_cls  # type: ignore[assignment]
-            # restore environ and stdio
-            os.environ = _orig_environ  # type: ignore[assignment]
-            sys.stdout = _saved_stdout  # type: ignore[assignment]
-            sys.stderr = _saved_stderr  # type: ignore[assignment]
 
     return wrapper

--- a/tests/test_detect_immutable.py
+++ b/tests/test_detect_immutable.py
@@ -1,23 +1,25 @@
+from collections.abc import Iterable
+
 import pytest
 from pure_function_decorators import detect_immutable
 
 
 @detect_immutable
-def touch_list(a):
+def touch_list(a: list[int]) -> int:
     a.append(3)
     return sum(a)
 
 
-def test_mutation_detected():
+def test_mutation_detected() -> None:
     with pytest.raises(RuntimeError) as ei:
         touch_list([1, 2])
     assert "Argument mutated" in str(ei.value)
 
 
 @detect_immutable
-def pure(a):
+def pure(a: Iterable[int]) -> tuple[int, ...]:
     return tuple(sorted(a))
 
 
-def test_no_mutation():
+def test_no_mutation() -> None:
     assert pure({3, 1, 2}) == (1, 2, 3)

--- a/tests/test_enforce_immutable.py
+++ b/tests/test_enforce_immutable.py
@@ -1,22 +1,24 @@
+from collections.abc import Iterable
+
 from pure_function_decorators import enforce_immutable
 
 
 @enforce_immutable
-def touch_list(a):
+def touch_list(a: list[int]) -> int:
     a.append(3)
     return sum(a)
 
 
-def test_mutation_prevented():
+def test_mutation_prevented() -> None:
     test_list = [1, 2, 3]
     touch_list(test_list)
     assert test_list == [1, 2, 3]
 
 
 @enforce_immutable
-def pure(a):
+def pure(a: Iterable[int]) -> tuple[int, ...]:
     return tuple(sorted(a))
 
 
-def test_no_mutation():
+def test_no_mutation() -> None:
     assert pure({3, 1, 2}) == (1, 2, 3)

--- a/tests/test_forbid_global_names.py
+++ b/tests/test_forbid_global_names.py
@@ -4,25 +4,25 @@ from pure_function_decorators import forbid_global_names
 CONST = 10
 
 
-def test_rejects_at_decoration_time():
+def test_rejects_at_decoration_time() -> None:
     with pytest.raises(RuntimeError):
 
         @forbid_global_names()
-        def bad(x):
+        def bad(x: int) -> int:  # pyright: ignore[reportUnusedFunction]
             return x + CONST  # triggers
 
 
-def test_allows_when_in_allow_list():
+def test_allows_when_in_allow_list() -> None:
     @forbid_global_names(allow=("CONST",))
-    def ok(x):
+    def ok(x: int) -> int:
         return x + CONST
 
     assert ok(1) == 11
 
 
-def test_works_without_parentheses():
+def test_works_without_parentheses() -> None:
     @forbid_global_names
-    def pure(x):
+    def pure(x: int) -> int:
         return x * 2
 
     assert pure(3) == 6

--- a/tests/test_forbid_globals.py
+++ b/tests/test_forbid_globals.py
@@ -5,19 +5,19 @@ CONST = 5
 
 
 @forbid_globals()
-def uses_const(x):
+def uses_const(x: int) -> int:
     return x + CONST  # blocked unless whitelisted
 
 
-def test_globals_blocked():
+def test_globals_blocked() -> None:
     with pytest.raises(NameError):
         uses_const(1)
 
 
 @forbid_globals(allow=("CONST",))
-def uses_const_ok(x):
+def uses_const_ok(x: int) -> int:
     return x + CONST
 
 
-def test_globals_allowed():
+def test_globals_allowed() -> None:
     assert uses_const_ok(2) == 7

--- a/tests/test_forbid_side_effects.py
+++ b/tests/test_forbid_side_effects.py
@@ -1,34 +1,37 @@
+from pathlib import Path
+
 import pytest
 from pure_function_decorators import forbid_side_effects
 
 
 @forbid_side_effects
-def do_print():
+def do_print() -> None:
     print("x")
 
 
-def test_print_blocked():
+def test_print_blocked() -> None:
     with pytest.raises(RuntimeError):
         do_print()
 
 
 @forbid_side_effects
-def do_open(tmp_path):
-    open(tmp_path / "f.txt", "w")  # type: ignore[arg-type]
+def do_open(tmp_path: Path) -> None:
+    with open(tmp_path / "f.txt", "w") as handle:
+        handle.write("x")
 
 
-def test_open_blocked(tmp_path):
+def test_open_blocked(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError):
         do_open(tmp_path)
 
 
 @forbid_side_effects
-def do_random():
+def do_random() -> float:
     import random
 
     return random.random()
 
 
-def test_random_blocked():
+def test_random_blocked() -> None:
     with pytest.raises(RuntimeError):
         do_random()


### PR DESCRIPTION
## Summary
- document the public package interface and refresh core decorators with type-aware wrappers
- harden detect_immutable with richer diff reporting, runtime aliases, and safer set handling
- align supporting tests with new typing expectations and add runtime guards against optional side effect APIs

## Testing
- ruff format src/pure_function_decorators tests
- ruff check --select I --fix src/pure_function_decorators tests
- pytest
- ruff check src/pure_function_decorators tests
- typos src/pure_function_decorators tests
- mypy src/pure_function_decorators tests --pretty
- basedpyright src/pure_function_decorators tests

------
https://chatgpt.com/codex/tasks/task_e_68d7f0f13e2883338e8e26985152f406