### PR TITLE
Fix lint issues in test suite

### DIFF
--- a/tests/test_detect_immutable.py
+++ b/tests/test_detect_immutable.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 import dataclasses
+from typing import TYPE_CHECKING
 
 import pytest
 from pure_function_decorators import detect_immutable
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @detect_immutable

--- a/tests/test_enforce_immutable.py
+++ b/tests/test_enforce_immutable.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 import dataclasses
+from typing import TYPE_CHECKING
 
 from pure_function_decorators import enforce_immutable
 
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 @enforce_immutable
 def touch_list(a: list[int]) -> int:

--- a/tests/test_forbid_side_effects.py
+++ b/tests/test_forbid_side_effects.py
@@ -65,7 +65,7 @@ def test_environ_blocked() -> None:
 def send_warning() -> None:
     import warnings
 
-    warnings.warn("nope")
+    warnings.warn("nope", stacklevel=2)
 
 
 def test_warnings_blocked() -> None:


### PR DESCRIPTION
## Summary
- defer Iterable imports in tests to type-checking blocks to satisfy lint rules
- include an explicit stacklevel when warning in side effects test to appease ruff

## Testing
- uv run ruff check src/pure_function_decorators tests

------
https://chatgpt.com/codex/tasks/task_e_68d7fe775340833389d49fdd976cd14d