### PR TITLE
Make decorators safe for concurrent execution

### DIFF
--- a/src/pure_function_decorators/enforce_deterministic.py
+++ b/src/pure_function_decorators/enforce_deterministic.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import pickle
+import threading
+from collections.abc import Awaitable
 from functools import wraps
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -15,19 +18,85 @@ else:  # pragma: no cover
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
+_MISSING = object()
+
+
+def _pickle_args(
+    args: _P.args, kwargs: _P.kwargs
+) -> bytes:  # pragma: no cover - tiny helper
+    return pickle.dumps((args, kwargs))
+
+
+def _sync_wrapper(
+    fn: Callable[_P, _T],
+) -> Callable[_P, _T]:
+    cache: dict[bytes, _T] = {}
+    lock = threading.RLock()
+
+    @wraps(fn)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        key = _pickle_args(args, kwargs)
+        with lock:
+            cached = cache.get(key, _MISSING)
+        result = fn(*args, **kwargs)
+        if cached is not _MISSING:
+            if cached != result:
+                raise ValueError("Non-deterministic output detected")
+            return result
+        with lock:
+            current = cache.get(key, _MISSING)
+            if current is not _MISSING and current != result:
+                raise ValueError("Non-deterministic output detected")
+            cache[key] = result
+        return result
+
+    return wrapper
+
+
+def _async_wrapper(
+    fn: Callable[_P, Awaitable[_T]],
+) -> Callable[_P, Awaitable[_T]]:
+    cache: dict[bytes, _T] = {}
+    lock = asyncio.Lock()
+
+    @wraps(fn)
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        key = _pickle_args(args, kwargs)
+        async with lock:
+            cached = cache.get(key, _MISSING)
+        result = await fn(*args, **kwargs)
+        if cached is not _MISSING:
+            if cached != result:
+                raise ValueError("Non-deterministic output detected")
+            return result
+        async with lock:
+            current = cache.get(key, _MISSING)
+            if current is not _MISSING and current != result:
+                raise ValueError("Non-deterministic output detected")
+            cache[key] = result
+        return result
+
+    return wrapper
+
+
+@overload
+def enforce_deterministic(
+    fn: Callable[_P, _T]
+) -> Callable[_P, _T]:  # pragma: no cover - typing overload
+    ...
+
+
+@overload
+def enforce_deterministic(
+    fn: Callable[_P, Awaitable[_T]]
+) -> Callable[_P, Awaitable[_T]]:  # pragma: no cover - typing overload
+    ...
 
 
 def enforce_deterministic(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     """Raise ``ValueError`` if ``fn`` returns different results for the same inputs."""
-    cache: dict[bytes, _T] = {}
 
-    @wraps(fn)
-    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        key = pickle.dumps((args, kwargs))
-        result = fn(*args, **kwargs)
-        if key in cache and cache[key] != result:
-            raise ValueError("Non-deterministic output detected")
-        cache[key] = result
-        return result
+    if asyncio.iscoroutinefunction(fn):
+        return _async_wrapper(fn)
 
-    return wrapper
+    return _sync_wrapper(fn)

--- a/src/pure_function_decorators/forbid_globals.py
+++ b/src/pure_function_decorators/forbid_globals.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import threading
+import inspect
+import types
 from functools import wraps
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
@@ -13,9 +14,50 @@ else:  # pragma: no cover
 
     Callable = _abc.Callable
 
-_GLOBAL_GUARD_LOCK = threading.RLock()
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
+
+
+def _build_minimal_globals(
+    fn: Callable[_P, _T], allow: tuple[str, ...]
+) -> dict[str, object]:
+    """Return a globals mapping limited to the provided allow-list."""
+
+    source_globals = fn.__globals__
+    minimal: dict[str, object] = {
+        "__builtins__": source_globals.get("__builtins__", __builtins__),
+        "__name__": source_globals.get("__name__", fn.__module__),
+        "__package__": source_globals.get("__package__"),
+        "__spec__": source_globals.get("__spec__"),
+        "__loader__": source_globals.get("__loader__"),
+        "__file__": source_globals.get("__file__"),
+        "__cached__": source_globals.get("__cached__"),
+    }
+    for name in allow:
+        if name in source_globals:
+            minimal[name] = source_globals[name]
+    return minimal
+
+
+def _make_sandboxed(
+    fn: Callable[_P, _T], minimal: dict[str, object]
+) -> Callable[_P, _T]:
+    """Create a clone of ``fn`` that uses ``minimal`` as its globals mapping."""
+
+    sandboxed = types.FunctionType(
+        fn.__code__,
+        minimal,
+        fn.__name__,
+        fn.__defaults__,
+        fn.__closure__,
+    )
+    sandboxed.__module__ = fn.__module__
+    sandboxed.__doc__ = fn.__doc__
+    sandboxed.__qualname__ = fn.__qualname__
+    sandboxed.__kwdefaults__ = getattr(fn, "__kwdefaults__", None)
+    sandboxed.__annotations__ = getattr(fn, "__annotations__", {}).copy()
+    minimal[fn.__name__] = sandboxed
+    return sandboxed
 
 
 def forbid_globals(
@@ -24,26 +66,20 @@ def forbid_globals(
     """Block reads or writes to ``fn.__globals__`` except for an allow-list."""
 
     def decorator(fn: Callable[_P, _T]) -> Callable[_P, _T]:
+
+        if inspect.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+                sandboxed = _make_sandboxed(fn, _build_minimal_globals(fn, allow))
+                return await sandboxed(*args, **kwargs)
+
+            return async_wrapper
+
         @wraps(fn)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-            globals_map = fn.__globals__
-            snapshot = dict(globals_map)
-            minimal = {
-                "__builtins__": snapshot.get("__builtins__", __builtins__),
-                fn.__name__: fn,
-            }
-            for name in allow:
-                if name in snapshot:
-                    minimal[name] = snapshot[name]
-
-            with _GLOBAL_GUARD_LOCK:
-                globals_map.clear()
-                globals_map.update(minimal)
-                try:
-                    return fn(*args, **kwargs)
-                finally:
-                    globals_map.clear()
-                    globals_map.update(snapshot)
+            sandboxed = _make_sandboxed(fn, _build_minimal_globals(fn, allow))
+            return sandboxed(*args, **kwargs)
 
         return wrapper
 

--- a/src/pure_function_decorators/forbid_side_effects.py
+++ b/src/pure_function_decorators/forbid_side_effects.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import builtins
 import concurrent.futures as futures
 import datetime
 import importlib
+import inspect
 import logging
 import multiprocessing
 import os
@@ -34,6 +36,31 @@ _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
 
+class _HybridRLock:
+    """Lock usable as both sync and async context manager."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+
+    def __enter__(self) -> _HybridRLock:
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._lock.release()
+
+    async def __aenter__(self) -> _HybridRLock:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._lock.acquire)
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        self._lock.release()
+
+
+_SIDE_EFFECT_LOCK = _HybridRLock()
+
+
 def _trap(name: str) -> Callable[..., NoReturn]:
     """Return a callable that raises ``RuntimeError`` when invoked."""
 
@@ -53,134 +80,156 @@ class _TrapStdIO:
         """Provide a harmless flush implementation for callers that expect one."""
         return None
 
+def _apply_patches() -> list[tuple[object, str, object]]:
+    patches: list[tuple[object, str, object]] = []
+
+    def patch(obj: object, attr: str, repl: object) -> None:
+        original = getattr(obj, attr)
+        setattr(obj, attr, repl)
+        patches.append((obj, attr, original))
+
+    patch(builtins, "print", _trap("print"))
+    patch(builtins, "open", _trap("open"))
+
+    patch(random, "random", _trap("random.random"))
+    patch(random, "randint", _trap("random.randint"))
+    patch(random, "randrange", _trap("random.randrange"))
+    patch(random, "choice", _trap("random.choice"))
+    patch(random, "shuffle", _trap("random.shuffle"))
+    patch(secrets, "token_bytes", _trap("secrets.token_bytes"))
+    patch(secrets, "token_hex", _trap("secrets.token_hex"))
+    patch(secrets, "token_urlsafe", _trap("secrets.token_urlsafe"))
+    patch(os, "urandom", _trap("os.urandom"))
+    patch(uuid, "uuid4", _trap("uuid.uuid4"))
+
+    patch(time, "time", _trap("time.time"))
+    patch(time, "sleep", _trap("time.sleep"))
+    patch(time, "monotonic", _trap("time.monotonic"))
+    patch(time, "perf_counter", _trap("time.perf_counter"))
+
+    class _TrapDateTime(datetime.datetime):
+        @override
+        @classmethod
+        def now(cls, *_args: object, **_kwargs: object) -> NoReturn:
+            raise RuntimeError("Side effect blocked: datetime.now")
+
+        @override
+        @classmethod
+        def utcnow(cls, *_args: object, **_kwargs: object) -> NoReturn:
+            raise RuntimeError("Side effect blocked: datetime.utcnow")
+
+        @override
+        @classmethod
+        def today(cls, *_args: object, **_kwargs: object) -> NoReturn:
+            raise RuntimeError("Side effect blocked: datetime.today")
+
+    patch(datetime, "datetime", _TrapDateTime)
+
+    patch(os, "getenv", _trap("os.getenv"))
+
+    class _TrapEnviron(dict[str, object]):
+        @override
+        def __getitem__(self, _key: str) -> NoReturn:
+            raise RuntimeError("Side effect blocked: os.environ[] read")
+
+        @override
+        def __setitem__(self, _key: str, _value: object) -> NoReturn:
+            raise RuntimeError("Side effect blocked: os.environ[] write")
+
+        @override
+        def get(self, _key: str, _default: object | None = None) -> NoReturn:
+            raise RuntimeError("Side effect blocked: os.environ.get")
+
+        @override
+        def __delitem__(self, _key: str) -> NoReturn:
+            raise RuntimeError("Side effect blocked: os.environ del")
+
+    patch(os, "environ", _TrapEnviron())
+
+    patch(os, "system", _trap("os.system"))
+    patch(os, "popen", _trap("os.popen"))
+    patch(os, "_exit", _trap("os._exit"))
+    patch(sys, "exit", _trap("sys.exit"))
+
+    patch(subprocess, "run", _trap("subprocess.run"))
+    patch(subprocess, "Popen", _trap("subprocess.Popen"))
+    patch(subprocess, "call", _trap("subprocess.call"))
+    patch(subprocess, "check_call", _trap("subprocess.check_call"))
+    patch(subprocess, "check_output", _trap("subprocess.check_output"))
+
+    patch(socket, "socket", _trap("socket.socket"))
+    with suppress(Exception):
+        import http.client as http_client
+
+        patch(http_client, "HTTPConnection", _trap("http.client.HTTPConnection"))
+        patch(http_client, "HTTPSConnection", _trap("http.client.HTTPSConnection"))
+
+    patch(threading.Thread, "start", _trap("threading.Thread.start"))
+    patch(multiprocessing.Process, "start", _trap("multiprocessing.Process.start"))
+    patch(
+        futures.ThreadPoolExecutor,
+        "__init__",
+        _trap("ThreadPoolExecutor.__init__"),
+    )
+    patch(
+        futures.ProcessPoolExecutor,
+        "__init__",
+        _trap("ProcessPoolExecutor.__init__"),
+    )
+
+    patch(logging.Logger, "_log", _trap("logging"))
+    patch(warnings, "warn", _trap("warnings.warn"))
+
+    patch(atexit, "register", _trap("atexit.register"))
+
+    patch(sys, "stdout", _TrapStdIO())
+    patch(sys, "stderr", _TrapStdIO())
+
+    with suppress(Exception):
+        sqlite3 = importlib.import_module("sqlite3")
+        patch(sqlite3, "connect", _trap("sqlite3.connect"))
+    with suppress(Exception):
+        psycopg2 = importlib.import_module("psycopg2")
+        patch(psycopg2, "connect", _trap("psycopg2.connect"))
+    with suppress(Exception):
+        mysql_connector = importlib.import_module("mysql.connector")
+        patch(
+            mysql_connector,
+            "connect",
+            _trap("mysql.connector.connect"),
+        )
+
+    return patches
+
+
+def _restore(patches: list[tuple[object, str, object]]) -> None:
+    for obj, attr, original in reversed(patches):
+        setattr(obj, attr, original)
+
 
 def forbid_side_effects(fn: Callable[_P, _T]) -> Callable[_P, _T]:
     """Reject attempts to perform common side effects while ``fn`` runs."""
 
+    if inspect.iscoroutinefunction(fn):
+
+        @wraps(fn)
+        async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+            async with _SIDE_EFFECT_LOCK:
+                patches = _apply_patches()
+                try:
+                    return await fn(*args, **kwargs)
+                finally:
+                    _restore(patches)
+
+        return async_wrapper
+
     @wraps(fn)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        patches: list[tuple[object, str, object]] = []
-
-        def patch(obj: object, attr: str, repl: object) -> None:
-            original = getattr(obj, attr)
-            setattr(obj, attr, repl)
-            patches.append((obj, attr, original))
-
-        patch(builtins, "print", _trap("print"))
-        patch(builtins, "open", _trap("open"))
-
-        patch(random, "random", _trap("random.random"))
-        patch(random, "randint", _trap("random.randint"))
-        patch(random, "randrange", _trap("random.randrange"))
-        patch(random, "choice", _trap("random.choice"))
-        patch(random, "shuffle", _trap("random.shuffle"))
-        patch(secrets, "token_bytes", _trap("secrets.token_bytes"))
-        patch(secrets, "token_hex", _trap("secrets.token_hex"))
-        patch(secrets, "token_urlsafe", _trap("secrets.token_urlsafe"))
-        patch(os, "urandom", _trap("os.urandom"))
-        patch(uuid, "uuid4", _trap("uuid.uuid4"))
-
-        patch(time, "time", _trap("time.time"))
-        patch(time, "sleep", _trap("time.sleep"))
-        patch(time, "monotonic", _trap("time.monotonic"))
-        patch(time, "perf_counter", _trap("time.perf_counter"))
-
-        class _TrapDateTime(datetime.datetime):
-            @override
-            @classmethod
-            def now(cls, *_args: object, **_kwargs: object) -> NoReturn:
-                raise RuntimeError("Side effect blocked: datetime.now")
-
-            @override
-            @classmethod
-            def utcnow(cls, *_args: object, **_kwargs: object) -> NoReturn:
-                raise RuntimeError("Side effect blocked: datetime.utcnow")
-
-            @override
-            @classmethod
-            def today(cls, *_args: object, **_kwargs: object) -> NoReturn:
-                raise RuntimeError("Side effect blocked: datetime.today")
-
-        patch(datetime, "datetime", _TrapDateTime)
-
-        patch(os, "getenv", _trap("os.getenv"))
-
-        class _TrapEnviron(dict[str, object]):
-            @override
-            def __getitem__(self, _key: str) -> NoReturn:
-                raise RuntimeError("Side effect blocked: os.environ[] read")
-
-            @override
-            def __setitem__(self, _key: str, _value: object) -> NoReturn:
-                raise RuntimeError("Side effect blocked: os.environ[] write")
-
-            @override
-            def get(self, _key: str, _default: object | None = None) -> NoReturn:
-                raise RuntimeError("Side effect blocked: os.environ.get")
-
-            @override
-            def __delitem__(self, _key: str) -> NoReturn:
-                raise RuntimeError("Side effect blocked: os.environ del")
-
-        patch(os, "environ", _TrapEnviron())
-
-        patch(os, "system", _trap("os.system"))
-        patch(os, "popen", _trap("os.popen"))
-        patch(os, "_exit", _trap("os._exit"))
-        patch(sys, "exit", _trap("sys.exit"))
-
-        patch(subprocess, "run", _trap("subprocess.run"))
-        patch(subprocess, "Popen", _trap("subprocess.Popen"))
-        patch(subprocess, "call", _trap("subprocess.call"))
-        patch(subprocess, "check_call", _trap("subprocess.check_call"))
-        patch(subprocess, "check_output", _trap("subprocess.check_output"))
-
-        patch(socket, "socket", _trap("socket.socket"))
-        with suppress(Exception):
-            import http.client as http_client
-
-            patch(http_client, "HTTPConnection", _trap("http.client.HTTPConnection"))
-            patch(http_client, "HTTPSConnection", _trap("http.client.HTTPSConnection"))
-
-        patch(threading.Thread, "start", _trap("threading.Thread.start"))
-        patch(multiprocessing.Process, "start", _trap("multiprocessing.Process.start"))
-        patch(
-            futures.ThreadPoolExecutor,
-            "__init__",
-            _trap("ThreadPoolExecutor.__init__"),
-        )
-        patch(
-            futures.ProcessPoolExecutor,
-            "__init__",
-            _trap("ProcessPoolExecutor.__init__"),
-        )
-
-        patch(logging.Logger, "_log", _trap("logging"))
-        patch(warnings, "warn", _trap("warnings.warn"))
-
-        patch(atexit, "register", _trap("atexit.register"))
-
-        patch(sys, "stdout", _TrapStdIO())
-        patch(sys, "stderr", _TrapStdIO())
-
-        with suppress(Exception):
-            sqlite3 = importlib.import_module("sqlite3")
-            patch(sqlite3, "connect", _trap("sqlite3.connect"))
-        with suppress(Exception):
-            psycopg2 = importlib.import_module("psycopg2")
-            patch(psycopg2, "connect", _trap("psycopg2.connect"))
-        with suppress(Exception):
-            mysql_connector = importlib.import_module("mysql.connector")
-            patch(
-                mysql_connector,
-                "connect",
-                _trap("mysql.connector.connect"),
-            )
-
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            for obj, attr, original in reversed(patches):
-                setattr(obj, attr, original)
+        with _SIDE_EFFECT_LOCK:
+            patches = _apply_patches()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _restore(patches)
 
     return wrapper


### PR DESCRIPTION
## Summary
- add thread-safe caching and coroutine support to `enforce_deterministic`
- sandbox globals without mutation so `forbid_globals` works safely with async callables
- guard side-effect traps with a hybrid lock to keep `forbid_side_effects` concurrency safe

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d8034bb564833396da8d75c7792a07