### PR TITLE
Document inability to apply decorators globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ The current decorators focus on globals, determinism, and structural immutabilit
 - **Dependency purity enforcement** &mdash; verify that functions only call other decorated or safelisted pure functions by walking the bytecode or AST.
 
 These ideas could live alongside the existing decorators as optional opt-in guards so projects can combine them to match their definition of purity.
+
+## Frequently asked questions
+
+### Can these decorators be enabled globally, like `perl`'s `strict` pragma?
+
+No. Python does not provide a hook that automatically wraps every function that is imported or defined after a module loads. The decorators in this project operate by returning a new callable, so each target function (or method) has to be wrapped explicitly. You can build your own helpers that iterate over a module or class and decorate selected callables, but the library cannot apply itself universally without the caller opting in on a per-function basis.

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -1,0 +1,5 @@
+# Frequently asked questions
+
+## Can the decorators be enabled globally, similar to Perl's `strict` pragma?
+
+Not currently. Python does not expose a way to automatically wrap every function or method that gets imported or defined after a module loads. Each decorator in this project returns a new callable, so you must opt in on a per-function basis (or build your own helper that walks a module or class and decorates the objects you choose). The library therefore cannot enforce purity checks globally without explicit wrapping.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,3 +5,8 @@ _Try to enforece various types of function purity in Python_
 
 ## Overview
 
+- [Quickstart](quickstart.md)
+- [Feature guide](features.md)
+- [Reference](reference.md)
+- [Frequently asked questions](faq.md)
+


### PR DESCRIPTION
## Summary
- add README guidance explaining that the decorators must be applied explicitly
- add a FAQ entry to the docs answering the global enablement question
- link the new FAQ from the documentation index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d842f546d88333b87b9f07b7c9be5f