### PR TITLE
Modernize for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mostly vibe-coded, though I hope to whittle down any issues
 
 ## Super-quick Start
 
-Requires: Python 3.10 to 3.13
+Requires: Python 3.13+
 
 Install through pip:
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* Python 3.10 to 3.13
+* Python 3.13+
 
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 license-files = ["LICENSE.md"]
 
-requires-python = ">=3.10, ~=3.13"
+requires-python = ">=3.13"
 dependencies = []
 
 

--- a/src/pure_function_decorators/forbid_side_effects.py
+++ b/src/pure_function_decorators/forbid_side_effects.py
@@ -21,16 +21,10 @@ import threading
 import time
 import uuid
 import warnings
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from functools import wraps
-from typing import TYPE_CHECKING, NoReturn, ParamSpec, TypeVar, cast, override
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-else:  # pragma: no cover
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
+from typing import NoReturn, ParamSpec, TypeVar, cast, override
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")

--- a/src/pure_function_decorators/immutable_arguments.py
+++ b/src/pure_function_decorators/immutable_arguments.py
@@ -5,21 +5,12 @@ from __future__ import annotations
 
 import copy
 import logging
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
+from typing import Any, ParamSpec, TypeVar, cast, overload
 
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping, Sequence
-else:  # pragma: no cover - provide runtime aliases for introspection tools
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
-    Iterable = _abc.Iterable
-    Mapping = _abc.Mapping
-    Sequence = _abc.Sequence
-
-_Path = tuple[str, ...]
-_Diff = tuple[_Path, str]
+type _Path = tuple[str, ...]
+type _Diff = tuple[_Path, str]
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 

--- a/src/pure_function_decorators/version.py
+++ b/src/pure_function_decorators/version.py
@@ -1,28 +1,36 @@
-"""docstring TBD."""
+"""Helpers for retrieving the project version at runtime."""
+
+from __future__ import annotations
 
 from importlib import metadata
+from pathlib import Path
 
 import tomllib
 
+_PYPROJECT_PATH = Path("pyproject.toml")
+
 
 def get_version_from_metadata() -> str:
-    """Return the version from metadata."""
+    """Return the version declared in installed package metadata."""
+
     return metadata.version(__package__ or __name__)
 
 
-def get_version_from_pyproject() -> str:
-    """Return the version from pyproject.toml."""
-    with open("pyproject.toml", "rb") as file:
-        return str(tomllib.load(file)["project"]["version"])
+def get_version_from_pyproject(path: Path = _PYPROJECT_PATH) -> str:
+    """Return the version declared in a ``pyproject.toml`` file."""
+
+    data = tomllib.loads(path.read_text("utf-8"))
+    return str(data["project"]["version"])
 
 
-def get_version() -> str:
-    """Return the version from metadata or pyproject.toml."""
+def get_version(path: Path = _PYPROJECT_PATH) -> str:
+    """Return the version from package metadata or the ``pyproject.toml`` file."""
+
     try:
         return get_version_from_metadata()
     except metadata.PackageNotFoundError:
         try:
-            return get_version_from_pyproject()
+            return get_version_from_pyproject(path)
         except (FileNotFoundError, KeyError):
             return "unknown"
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-from importlib import metadata
+import importlib.metadata as metadata
 from importlib.metadata import PackageNotFoundError
 from unittest import mock
 


### PR DESCRIPTION
## Summary
- require Python 3.13 across packaging metadata and documentation
- simplify runtime imports and adopt modern type alias syntax across decorators
- refresh version helpers to use pathlib and update tests accordingly

## Testing
- `python -m compileall src`
- `uv run pytest` *(fails: network access to fetch pytest-pretty)*
- `pytest` *(fails: optional plugins missing without dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d88bcaefd48333aff5af96e9956df1