### PR TITLE
Update Python requirement range to include 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 license-files = ["LICENSE.md"]
 
-requires-python = ">=3.10, ~=3.13"
+requires-python = ">=3.12, <4"
 dependencies = []
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.13, <4"
+requires-python = ">=3.12, <4"
 
 [[package]]
 name = "asttokens"


### PR DESCRIPTION
## Summary
- widen the supported Python range to >=3.12,<4 in both project metadata and the uv lockfile

## Testing
- uv sync --python 3.12 *(fails: unable to reach https://pypi.org/simple/pytest-random-order/)*

------
https://chatgpt.com/codex/tasks/task_e_68d92d0ee9548333a7f70086d700583d