### PR TITLE
Adopt Python 3.12 typing conveniences

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ any actual utility is just a bonus
 
 Requires: Python >= 3.12
 
+The implementation adopts modern standard-library typing helpers such as
+``typing.override`` and ``typing.Self``, so earlier interpreters are not
+supported.
+
 Install through pip:
 
 ```bash

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -2,7 +2,10 @@
 
 ## Requirements
 
-* Python 3.10 to 3.13
+* Python 3.12 or newer
+
+The library leans on modern typing improvements such as :func:`typing.override`
+and :class:`typing.Self`, so earlier interpreters are not supported.
 
 
 ## Installation

--- a/src/pure_function_decorators/__init__.py
+++ b/src/pure_function_decorators/__init__.py
@@ -1,11 +1,13 @@
 """Public package surface for the pure-function-decorators project."""
 
+from typing import Final
+
 from .enforce_deterministic import enforce_deterministic
 from .forbid_globals import forbid_globals
 from .forbid_side_effects import forbid_side_effects
 from .immutable_arguments import immutable_arguments
 
-__all__ = [
+__all__: Final = [
     "enforce_deterministic",
     "forbid_globals",
     "forbid_side_effects",

--- a/src/pure_function_decorators/enforce_deterministic.py
+++ b/src/pure_function_decorators/enforce_deterministic.py
@@ -5,21 +5,14 @@ from __future__ import annotations
 import asyncio
 import pickle
 import threading
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-else:  # pragma: no cover
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
+from typing import Final, ParamSpec, TypeVar, cast
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 _AwaitedT = TypeVar("_AwaitedT")
-_MISSING = object()
+_MISSING: Final = object()
 
 
 def _pickle_args(

--- a/src/pure_function_decorators/forbid_globals.py
+++ b/src/pure_function_decorators/forbid_globals.py
@@ -6,18 +6,12 @@ import builtins
 import dis
 import inspect
 import types
+from collections.abc import Awaitable, Callable, Iterable
 from functools import wraps
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast, overload
+from typing import Final, ParamSpec, TypeVar, cast, overload
 
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterable
-else:  # pragma: no cover
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
-
-_GLOBAL_OPS = {"LOAD_GLOBAL", "STORE_GLOBAL", "DELETE_GLOBAL"}
-_IMPORT_OPS = {"IMPORT_NAME"}
+_GLOBAL_OPS: Final = {"LOAD_GLOBAL", "STORE_GLOBAL", "DELETE_GLOBAL"}
+_IMPORT_OPS: Final = {"IMPORT_NAME"}
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 

--- a/src/pure_function_decorators/forbid_side_effects.py
+++ b/src/pure_function_decorators/forbid_side_effects.py
@@ -23,14 +23,9 @@ import uuid
 import warnings
 from contextlib import suppress
 from functools import wraps
-from typing import TYPE_CHECKING, NoReturn, ParamSpec, TypeVar, cast, override
+from typing import Final, NoReturn, ParamSpec, Self, TypeVar, cast, override
 
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-else:  # pragma: no cover
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
+from collections.abc import Awaitable, Callable
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -44,7 +39,7 @@ class _HybridRLock:
 
         self._lock: threading.RLock = threading.RLock()
 
-    def __enter__(self) -> _HybridRLock:
+    def __enter__(self) -> Self:
         """Acquire the lock for use in a synchronous ``with`` block.
 
         Returns
@@ -61,7 +56,7 @@ class _HybridRLock:
 
         self._lock.release()
 
-    async def __aenter__(self) -> _HybridRLock:
+    async def __aenter__(self) -> Self:
         """Acquire the lock for use in an ``async with`` block.
 
         Returns
@@ -80,7 +75,7 @@ class _HybridRLock:
         self._lock.release()
 
 
-_SIDE_EFFECT_LOCK = _HybridRLock()
+_SIDE_EFFECT_LOCK: Final = _HybridRLock()
 
 
 def _trap(name: str) -> Callable[..., NoReturn]:

--- a/src/pure_function_decorators/immutable_arguments.py
+++ b/src/pure_function_decorators/immutable_arguments.py
@@ -5,25 +5,16 @@ from __future__ import annotations
 
 import copy
 import logging
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping, Sequence
-else:  # pragma: no cover - provide runtime aliases for introspection tools
-    import collections.abc as _abc
-
-    Callable = _abc.Callable
-    Iterable = _abc.Iterable
-    Mapping = _abc.Mapping
-    Sequence = _abc.Sequence
+from typing import Any, Final, ParamSpec, TypeVar, cast, overload
 
 _Path = tuple[str, ...]
 _Diff = tuple[_Path, str]
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: Final = logging.getLogger(__name__)
 
 __all__ = ["immutable_arguments"]
 

--- a/src/pure_function_decorators/version.py
+++ b/src/pure_function_decorators/version.py
@@ -1,23 +1,32 @@
-"""docstring TBD."""
+"""Helpers for resolving the package version in development and runtime."""
+
+from __future__ import annotations
 
 from importlib import metadata
+from pathlib import Path
+from typing import Final
 
 import tomllib
 
+_PYPROJECT_PATH: Final = Path("pyproject.toml")
+
 
 def get_version_from_metadata() -> str:
-    """Return the version from metadata."""
+    """Return the version published in the installed package metadata."""
+
     return metadata.version(__package__ or __name__)
 
 
 def get_version_from_pyproject() -> str:
-    """Return the version from pyproject.toml."""
-    with open("pyproject.toml", "rb") as file:
-        return str(tomllib.load(file)["project"]["version"])
+    """Return the version declared in ``pyproject.toml`` for local builds."""
+
+    data = tomllib.loads(_PYPROJECT_PATH.read_text("utf-8"))
+    return str(data["project"]["version"])
 
 
 def get_version() -> str:
-    """Return the version from metadata or pyproject.toml."""
+    """Return the version from metadata or ``pyproject.toml`` as a fallback."""
+
     try:
         return get_version_from_metadata()
     except metadata.PackageNotFoundError:
@@ -27,4 +36,4 @@ def get_version() -> str:
             return "unknown"
 
 
-__version__ = get_version()
+__version__: Final = get_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,8 @@
-from importlib import metadata
 from importlib.metadata import PackageNotFoundError
 from unittest import mock
 
 import pytest
+
 from pure_function_decorators.version import (
     __version__,
     get_version,
@@ -14,7 +14,7 @@ from pure_function_decorators.version import (
 def test_get_version_from_metadata() -> None:
     try:
         value = get_version_from_metadata()
-    except metadata.PackageNotFoundError:
+    except PackageNotFoundError:
         pytest.skip("package metadata not available")
     assert value == __version__
 


### PR DESCRIPTION
## Summary
- rely on native `collections.abc` generics and `typing.Final` across the decorators instead of compatibility shims
- tighten helpers for side-effect detection and version discovery with Python 3.12 conveniences such as `typing.Self` and `pathlib.Path`
- refresh documentation and tests to spell out the Python 3.12+ requirement and updated imports

## Testing
- pytest --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d933b3a4a8833399f1eacb757dd908