### PR TITLE
Add optional enabled and strict controls to decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,18 @@ The complete documentation can be found at the
 ## Existing decorators
 
 - `immutable_arguments` deep-copies inputs before invoking the wrapped callable so callers never see in-place mutations.
-    - By default, the decorator raises when a mutation is detected
-    - it can instead log warnings with `warn_only=True`.
+    - By default, the decorator raises when a mutation is detected.
+    - Use `warn_only=True` or `strict=False` to log warnings instead of raising, or `enabled=False` to bypass checks.
 - `enforce_deterministic` ensures that the decorated function consistently returns the same result for the same
   parameters.
+    - Set `strict=False` to emit warnings when nondeterministic behaviour is observed or `enabled=False` to skip wrapping.
 - `forbid_globals` prevents a function from reading or mutating module-level state by sandboxing its globals.
     - `check_names=True` to also fail decoration when bytecode references globals outside the allow-list, or set
     - `sandbox=False` to keep only the bytecode-based validation.
+    - Configure `strict=False` to log name-check violations instead of raising or `enabled=False` to leave the function unchanged.
 - `forbid_side_effects` instruments builtin operations that commonly mutate process state (e.g. file writes, subprocess
   launches) to surface accidental side effects.
+    - Pass `strict=False` to warn and allow the attempted side effect or `enabled=False` to skip patching entirely.
 
 ## Future purity checks to explore
 

--- a/tests/test_forbid_globals.py
+++ b/tests/test_forbid_globals.py
@@ -72,3 +72,12 @@ def test_async_globals_allowed() -> None:
         assert await async_uses_const_ok(3) == 8
 
     asyncio.run(runner())
+
+
+@forbid_globals(enabled=False)
+def relaxed(x: int) -> int:
+    return x + CONST
+
+
+def test_enabled_false_leaves_function_untouched() -> None:
+    assert relaxed(4) == 9

--- a/tests/test_forbid_globals_name_checks.py
+++ b/tests/test_forbid_globals_name_checks.py
@@ -67,3 +67,16 @@ def test_import_detected_unless_disabled() -> None:
         del math
 
     load_module_ok()
+
+
+def test_check_names_strict_false_warns(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("WARNING")
+
+    @forbid_globals(check_names=True, sandbox=False, strict=False)
+    def relaxed(x: int) -> int:
+        return x + CONST
+
+    assert relaxed(1) == 11
+    assert any(
+        "Global names referenced" in message for message in caplog.messages
+    )

--- a/tests/test_forbid_side_effects.py
+++ b/tests/test_forbid_side_effects.py
@@ -95,3 +95,28 @@ def test_pure_function_succeeds() -> None:
     # restore the patched globals afterwards so ``print`` works as normal.
     assert pure_function(2, 3) == 5
     print("side effects restored")
+
+
+@forbid_side_effects(strict=False)
+def relaxed_print() -> int:
+    print("relaxed")
+    return 42
+
+
+def test_strict_false_warns_and_allows(capfd: pytest.CaptureFixture[str]) -> None:
+    assert relaxed_print() == 42
+    captured = capfd.readouterr()
+    assert "relaxed" in captured.out
+    assert "Side effect blocked" in captured.err
+
+
+@forbid_side_effects(enabled=False)
+def allowed_print() -> None:
+    print("allowed")
+
+
+def test_enabled_false_does_not_patch(capfd: pytest.CaptureFixture[str]) -> None:
+    allowed_print()
+    captured = capfd.readouterr()
+    assert captured.out == "allowed\n"
+    assert "Side effect blocked" not in captured.err

--- a/tests/test_immutable_arguments.py
+++ b/tests/test_immutable_arguments.py
@@ -108,3 +108,33 @@ def test_warn_only_returns_mutated_values(caplog: pytest.LogCaptureFixture) -> N
     assert mutated_args == [1, 2, 3, 99]
     assert mutated_payload == [4, 5, 42]
     assert any("Argument mutated" in message for message in caplog.messages)
+
+
+def test_strict_false_logs(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("WARNING")
+
+    @immutable_arguments(strict=False)
+    def mutate(data: list[int]) -> list[int]:
+        data.append(5)
+        return data
+
+    original = [1, 2]
+    result = mutate(original)
+
+    assert original == [1, 2]
+    assert result == [1, 2, 5]
+    assert any("Argument mutated" in message for message in caplog.messages)
+
+
+def test_enabled_false_disables_checks() -> None:
+
+    @immutable_arguments(enabled=False)
+    def mutate(data: list[int]) -> list[int]:
+        data.append(7)
+        return data
+
+    payload = [1, 2]
+    result = mutate(payload)
+
+    assert payload == [1, 2, 7]
+    assert result is payload


### PR DESCRIPTION
## Summary
- add `enabled` and `strict` parameters across the decorators so they can be disabled or converted to warning-only mode
- update the runtime implementations to emit warnings instead of raising when `strict=False`, including relaxed side-effect trapping
- refresh the README and test suite to cover the new configuration points

## Testing
- pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d93ae180e48333848118621b775089