### PR TITLE
Move collections imports under TYPE_CHECKING

### DIFF
--- a/src/pure_function_decorators/enforce_deterministic.py
+++ b/src/pure_function_decorators/enforce_deterministic.py
@@ -7,8 +7,10 @@ import logging
 import pickle
 import threading
 from functools import wraps
-from typing import Final, cast, overload
-from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Final, cast, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 _MISSING: Final = object()
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/pure_function_decorators/forbid_globals.py
+++ b/src/pure_function_decorators/forbid_globals.py
@@ -8,8 +8,10 @@ import inspect
 import logging
 import types
 from functools import wraps
-from typing import Final, cast, overload
-from collections.abc import Awaitable, Callable, Iterable
+from typing import TYPE_CHECKING, Final, cast, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable
 
 _GLOBAL_OPS: Final = {"LOAD_GLOBAL", "STORE_GLOBAL", "DELETE_GLOBAL"}
 _IMPORT_OPS: Final = {"IMPORT_NAME"}

--- a/src/pure_function_decorators/immutable_arguments.py
+++ b/src/pure_function_decorators/immutable_arguments.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import copy
 import logging
 from functools import wraps
-from typing import Any, Final, cast, overload
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Final, cast, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
 
 _Path = tuple[str, ...]
 _Diff = tuple[_Path, str]


### PR DESCRIPTION
## Summary
- move collections.abc type-only imports behind TYPE_CHECKING in enforcement decorators

## Testing
- make qa *(fails: unable to download build requirement `hatchling` in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97be23b0883338b91d5727e3625d9