### PR TITLE
Fix mypy errors and harden datetime trapping

### DIFF
--- a/tests/test_forbid_side_effects.py
+++ b/tests/test_forbid_side_effects.py
@@ -3,6 +3,7 @@ import random
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 import pytest
 from pure_function_decorators import forbid_side_effects
@@ -193,4 +194,4 @@ def test_relaxed_environ_operations_warn() -> None:
         if original is sentinel:
             os.environ.pop(key, None)
         else:
-            os.environ[key] = original
+            os.environ[key] = cast("str", original)


### PR DESCRIPTION
## Summary
- guard stderr writes in `_emit_warning` so logging works even when the original stream is missing
- tighten the `os.environ` proxy typing and add a factory for strict/relaxed datetime replacements
- teach the relaxed datetime proxy to defer to the base implementation while emitting warnings and fix the mypy issue in the tests

## Testing
- `UV_NO_SYNC=1 uv run pytest`
- `UV_NO_SYNC=1 uv run ruff check src/pure_function_decorators tests`
- `UV_NO_SYNC=1 uv run mypy src/pure_function_decorators tests --pretty`


------
https://chatgpt.com/codex/tasks/task_e_68d97cb2cd5c8333920c9a80bc8a0167